### PR TITLE
removing rsync dependency

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -30,6 +30,9 @@
 #			type: dockerRegistryLogin
 
 templates: &build-test-push
+  - export HUB_USERNAME=$(shipctl get_integration_field "dockerhub" "username")
+  - export HUB_PASSWORD=$(shipctl get_integration_field "dockerhub" "password")
+  - docker login --username $HUB_USERNAME --password $HUB_PASSWORD
   - cd $(shipctl get_resource_state "freeipa-container-gitRepo")
   - sed -i 's|registry.fedoraproject.org/||' Dockerfile.fedora-27
   - sed -i 's/^# debug:\s*//' Dockerfile.fedora-27

--- a/shippable.yml
+++ b/shippable.yml
@@ -56,7 +56,6 @@ jobs:
       - dockerhub
     steps:
       - IN: freeipa-container-gitRepo
-      - IN: freeipa-container_master_rSync
       - TASK:
           runtime:
             options:
@@ -77,7 +76,6 @@ jobs:
       - dockerhub
     steps:
       - IN: freeipa-container-gitRepo
-      - IN: freeipa-container_master_rSync
       - TASK:
           runtime:
             options:


### PR DESCRIPTION
- based on the current assembly line structure, if there are any changes in `shippable.yml`, all three jobs (rsync, arm64, amd64) will trigger simultaneously since they all have the gitRepo as an `IN`. Once `rSync` finishes, it'll **again** trigger all the downstream jobs. Im assuming that's not really what's required here
- a better workflow would something like this
    - if the assembly line config changes, run `rSync` to update this. Since shippable.yml's tend to change rarely once the configuration is done, this job will not be run with each commit.
    - if any other file changes, run any other jobs that have the gitRepo as an `IN`
- feel free to close this PR if this is not what you're looking for :)

**update**
 - also fixing the docker login issue. 
- PS: im realizing that a **lot** of docs need to be updated from our end. We'll get started on those while this PR should get you unblocked finally